### PR TITLE
Use Hash#[] insted of Hash#merge!

### DIFF
--- a/lib/to_lookup_hash.rb
+++ b/lib/to_lookup_hash.rb
@@ -3,14 +3,16 @@ require "to_lookup_hash/version"
 module Enumerable
   def to_lookup_hash
     inject({}) do |memo, element|
-      memo.merge!(yield(element) => element)
+      memo[yield(element)] = element
+      memo
     end
   end
 
   def to_lookup_hash_with_value
     inject({}) do |memo, element|
       key, value = yield(element)
-      memo.merge!(key => value)
+      memo[key] = value
+      memo
     end
   end
 end


### PR DESCRIPTION
Merge creates new hash for each iteration.
Using `Hash#[]` is faster:
```
require 'benchmark/ips'

array = 1_000.times.map { rand(1000) }

Benchmark.ips do |x|
  x.report('#to_lookup_hash (before)') { array.to_lookup_hash_old { |v| v } }
  x.report('#to_lookup_hash (after)')  { array.to_lookup_hash { |v| v } }
  x.compare!
end

Benchmark.ips do |x|
  x.report('#to_lookup_hash_with_value (before)') { array.to_lookup_hash_with_value_old { |v| [v, v * 2] } }
  x.report('#to_lookup_hash_with_value (after)')  { array.to_lookup_hash_with_value { |v| [v, v * 2] } }
  x.compare!
end

Warming up --------------------------------------
#to_lookup_hash (before)
                        93.000  i/100ms
#to_lookup_hash (after)
                       283.000  i/100ms
Calculating -------------------------------------
#to_lookup_hash (before)
                        900.574  (± 6.0%) i/s -      4.557k in   5.077786s
#to_lookup_hash (after)
                          3.261k (±29.0%) i/s -     14.433k in   5.037823s

Comparison:
#to_lookup_hash (after):     3260.9 i/s
#to_lookup_hash (before):      900.6 i/s - 3.62x  slower

Warming up --------------------------------------
#to_lookup_hash_with_value (before)
                        96.000  i/100ms
#to_lookup_hash_with_value (after)
                       236.000  i/100ms
Calculating -------------------------------------
#to_lookup_hash_with_value (before)
                        935.921  (± 5.3%) i/s -      4.704k in   5.040152s
#to_lookup_hash_with_value (after)
                          2.412k (± 9.0%) i/s -     12.036k in   5.066182s

Comparison:
#to_lookup_hash_with_value (after):     2412.4 i/s
#to_lookup_hash_with_value (before):      935.9 i/s - 2.58x  slower
```
And allocates less memory:
```
array = 1_000.times.map { rand(1000) }
require 'memory_profiler'

report = MemoryProfiler.report do
  1000.times { array.to_lookup_hash_old { |v| v } }
end
print_results(report, '#to_lookup_hash (before)')

report = MemoryProfiler.report do
  1000.times { array.to_lookup_hash { |v| v } }
end
print_results(report, '#to_lookup_hash (after)')

static_result = [1,1]

report = MemoryProfiler.report do
  1000.times { array.to_lookup_hash_with_value_old { |v| static_result } }
end
print_results(report, '#to_lookup_hash_with_value (before)')

report = MemoryProfiler.report do
  1000.times { array.to_lookup_hash_with_value { |v| static_result } }
end
print_results(report, '#to_lookup_hash_with_value (after)')

#to_lookup_hash (before)
Total allocated: 263232000 bytes (1001000 objects)
Total retained:  0 bytes (0 objects)


#to_lookup_hash (after)
Total allocated: 31232000 bytes (1000 objects)
Total retained:  0 bytes (0 objects)


#to_lookup_hash_with_value (before)
Total allocated: 232232000 bytes (1001000 objects)
Total retained:  0 bytes (0 objects)


#to_lookup_hash_with_value (after)
Total allocated: 232000 bytes (1000 objects)
Total retained:  0 bytes (0 objects)
```