### PR TITLE
update gemspec license and authors

### DIFF
--- a/lib/to_lookup_hash/version.rb
+++ b/lib/to_lookup_hash/version.rb
@@ -1,3 +1,3 @@
 module ToLookupHash
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/to_lookup_hash.gemspec
+++ b/to_lookup_hash.gemspec
@@ -6,12 +6,12 @@ require 'to_lookup_hash/version'
 Gem::Specification.new do |spec|
   spec.name          = "to_lookup_hash"
   spec.version       = ToLookupHash::VERSION
-  spec.authors       = ["Paweł Obrok"]
-  spec.email         = ["pawel.obrok@gmail.com"]
+  spec.authors       = ["Zendesk"]
+  spec.email         = ["opensource@zendesk.com"]
   spec.description   = %q{Adds methods for converting enumerables to lookup hashes}
   spec.summary       = %q{Adds methods for converting enumerables to lookup hashes}
   spec.homepage      = "https://github.com/basecrm/to_lookup_hash"
-  spec.license       = "MIT"
+  spec.license       = "Apache License Version 2.0"
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
update gemspec with updated license to Apache 2 and use company wide author and email Zendesk and opensource@zendesk.com. to release in rubygems patch version is bumped.